### PR TITLE
Calc top n

### DIFF
--- a/src/malco/post_process/compute_mrr.py
+++ b/src/malco/post_process/compute_mrr.py
@@ -122,7 +122,7 @@ def compute_mrr(output_dir, prompt_dir, correct_answer_file) -> Path:
             i = i + 1
 
     
-    topn_file = output_dir / "topn_result.tsv"
+    topn_file = output_dir / "plots/topn_result.tsv"
     # use rank_df.to_csv() or something similar
     rank_df.to_csv(topn_file, sep='\t', index=False)
 
@@ -138,4 +138,5 @@ def compute_mrr(output_dir, prompt_dir, correct_answer_file) -> Path:
         writer = csv.writer(dat, quoting = csv.QUOTE_NONNUMERIC, delimiter = '\t', lineterminator='\n')
         writer.writerow(results_files)
         writer.writerow(mrr_scores)
-    return plot_data_file, plot_dir, num_ppkt
+        
+    return plot_data_file, plot_dir, num_ppkt, topn_file

--- a/src/malco/post_process/compute_mrr.py
+++ b/src/malco/post_process/compute_mrr.py
@@ -126,12 +126,6 @@ def compute_mrr(output_dir, prompt_dir, correct_answer_file) -> Path:
     # use rank_df.to_csv() or something similar
     rank_df.to_csv(topn_file, sep='\t', index=False)
 
-    '''
-    with topn_file.open('w', newline = '') as topn:
-        writer = csv.writer(topn, quoting = csv.QUOTE_NONNUMERIC, delimiter = '\t', lineterminator='\n')
-        writer.writerow(header)
-        writer.writerow(topn_vals)
-    '''
 
     print("MRR scores are:\n")
     print(mrr_scores)

--- a/src/malco/post_process/generate_plots.py
+++ b/src/malco/post_process/generate_plots.py
@@ -1,11 +1,12 @@
 import seaborn as sns
 import matplotlib.pyplot as plt
+import pandas as pd
 import os
 import csv
 
 # Make a nice plot, use it as function or as script
 
-def make_plots(plot_data_file, plot_dir, languages, num_ppkt):
+def make_plots(plot_data_file, plot_dir, languages, num_ppkt, topn_file):
     with plot_data_file.open('r', newline = '') as f:
         lines = csv.reader(f, quoting = csv.QUOTE_NONNUMERIC, delimiter = '\t', lineterminator='\n')
         results_files = next(lines)
@@ -15,7 +16,7 @@ def make_plots(plot_data_file, plot_dir, languages, num_ppkt):
     print(results_files)
     print(mrr_scores)
 
-    # Plotting the results
+    # Plotting the mrr results
     sns.barplot(x = results_files, y = mrr_scores)
     plt.xlabel("Results File")
     plt.ylabel("Mean Reciprocal Rank (MRR)")
@@ -23,3 +24,24 @@ def make_plots(plot_data_file, plot_dir, languages, num_ppkt):
     plot_path = plot_dir /  (str(len(languages)) + "_langs_" + str(num_ppkt) + "ppkt.png")
     plt.savefig(plot_path)
     plt.show()
+
+    # Plotting bar-plots with top<n> ranks
+    df = pd.read_csv(topn_file, delimiter='\t')
+    df["top1"] = df['n1']
+    df["top3"] = df["n1"] + df["n2"] + df["n3"]
+    df["top5"] = df["top3"] + df["n4"] + df["n5"]
+    df["top10"] = df["top5"] + df["n6"] + df["n7"] + df["n8"] + df["n9"] + df["n10"]
+    df["not_found"] = df["nf"]
+    
+    df_aggr = pd.DataFrame()
+    df_aggr = pd.melt(df, id_vars="lang", value_vars=["top1", "top3", "top5", "top10", "not_found"], var_name="Rank_in", value_name="counts")
+    sns.barplot(x="Rank_in", y="counts", data = df_aggr, hue = "lang")
+
+    plt.xlabel("Number of Ranks")
+    plt.ylabel("Number of Correct Diagnoses")
+    plt.title("Rank Comparison for Different Languages")
+    plot_path = plot_dir /  ("barplot_" + str(len(languages)) + "_langs_" + str(num_ppkt) + "ppkt.png")
+    plt.savefig(plot_path)
+    plt.show()
+
+    

--- a/src/malco/post_process/generate_plots.py
+++ b/src/malco/post_process/generate_plots.py
@@ -23,7 +23,6 @@ def make_plots(plot_data_file, plot_dir, languages, num_ppkt, topn_file):
     plt.title("MRR of Correct Answers Across Different Results Files")
     plot_path = plot_dir /  (str(len(languages)) + "_langs_" + str(num_ppkt) + "ppkt.png")
     plt.savefig(plot_path)
-    plt.show()
 
     # Plotting bar-plots with top<n> ranks
     df = pd.read_csv(topn_file, delimiter='\t')
@@ -35,6 +34,9 @@ def make_plots(plot_data_file, plot_dir, languages, num_ppkt, topn_file):
     
     df_aggr = pd.DataFrame()
     df_aggr = pd.melt(df, id_vars="lang", value_vars=["top1", "top3", "top5", "top10", "not_found"], var_name="Rank_in", value_name="counts")
+    bar_data_file = plot_dir / "topn_aggr.tsv"
+    df_aggr.to_csv(bar_data_file, sep='\t', index=False)
+
     sns.barplot(x="Rank_in", y="counts", data = df_aggr, hue = "lang")
 
     plt.xlabel("Number of Ranks")

--- a/src/malco/post_process/mondo_score_utils.py
+++ b/src/malco/post_process/mondo_score_utils.py
@@ -72,7 +72,6 @@ def score_grounded_result(prediction: str, ground_truth: str, mondo) -> float:
         # predication is the correct OMIM
         return FULL_SCORE
 
-    #if ground_truth in omim_mappings(prediction, mondo):
     if ground_truth in omim_mappings(prediction, mondo):
         # prediction is a MONDO that directly maps to a correct OMIM
         return FULL_SCORE

--- a/src/malco/runner.py
+++ b/src/malco/runner.py
@@ -58,10 +58,10 @@ class MalcoRunner(PhEvalRunner):
                      output_dir=self.output_dir,
                      langs=self.languages)
 
-        plot_data_file, plot_dir, num_ppkt = (
-            compute_mrr(output_dir=self.output_dir,
-                        prompt_dir=os.path.join(self.input_dir, prompts_subdir_name),
-                        correct_answer_file=correct_answer_file)
-        )
+        plot_data_file, plot_dir, num_ppkt, topn_file = compute_mrr(
+            output_dir=self.output_dir,
+            prompt_dir=os.path.join(self.input_dir, prompts_subdir_name),
+            correct_answer_file=correct_answer_file)
+        
         if print_plot:
-            make_plots(plot_data_file, plot_dir, self.languages, num_ppkt)
+            make_plots(plot_data_file, plot_dir, self.languages, num_ppkt, topn_file)


### PR DESCRIPTION
Added extraction and then saving (as tsv) of a dataframe containing one line per language. 
The columns are
n1, n2, n3, ... n10, n10p, nf,  meaning :
n1 = counts of diagnoses with rank number 1, 
similarly for n<i> up to i=10,
n10p, which gathers all ranks greater than 10 (if there are any),
nf meaning not found. 

In this way we save the exact number of diseases with rank number 1,2...10, with the idea of aggregating for top3, top5, ... and then plotting in a separate script (TODO).

Probably easier things can be done in pandas, my not too braod experience led me to this:

https://github.com/monarch-initiative/malco/blob/9f576f3b39f36869cd0b73272053eb2c726f5fe1/src/malco/post_process/compute_mrr.py#L90-L111 