### PR TITLE
gh error, now really: added saving of df with full result

### DIFF
--- a/src/malco/runner.py
+++ b/src/malco/runner.py
@@ -61,7 +61,8 @@ class MalcoRunner(PhEvalRunner):
         plot_data_file, plot_dir, num_ppkt, topn_file = compute_mrr(
             output_dir=self.output_dir,
             prompt_dir=os.path.join(self.input_dir, prompts_subdir_name),
-            correct_answer_file=correct_answer_file)
+            correct_answer_file=correct_answer_file,
+            raw_results_dir=self.raw_results_dir)
         
         if print_plot:
             make_plots(plot_data_file, plot_dir, self.languages, num_ppkt, topn_file)


### PR DESCRIPTION
Needed for bookkeeping but also for further investigations into characteristics of diseases easily found (or not) by LLM.

With this PR output of so called "full results" is now in output_dir/raw_results/{language_code}/full_df_results.tsv and look like:

![image](https://github.com/user-attachments/assets/5c3f656e-f7ce-4b3e-b908-40d9175c7193)

Solves #38 (unless we want more granularity in the Phenotypic Series).

P.s.: I apparently created the branch, pushed an empty (i.e. identical to main) version to remote, and then repushed the same thing and... it worked, weird! I think it's again tied to using simultaneously git cli and through VScode plugins 