### PR TITLE
added multiple models, along the lines of multiple languages. 

### DIFF
--- a/src/malco/post_process/compute_mrr.py
+++ b/src/malco/post_process/compute_mrr.py
@@ -30,7 +30,7 @@ def compute_mrr(output_dir, prompt_dir, correct_answer_file,
     results_files = []
     num_ppkt = 0
 
-    for subdir, dirs, files in os.walk(output_dir):
+    for subdir, dirs, files in os.walk(output_dir): # maybe change this so it only looks into multilingual/multimodel? I.e. use that as outputdir...?
         for filename in files:
             if filename.startswith("result") and filename.endswith(".tsv"):
                 file_path = os.path.join(subdir, filename)
@@ -85,7 +85,7 @@ def compute_mrr(output_dir, prompt_dir, correct_answer_file,
             )
 
             # Save full data frame
-            full_df_file = raw_results_dir / results_files[i][0:2] / "full_df_results.tsv"
+            full_df_file = raw_results_dir / results_files[i].split("/")[0] / "full_df_results.tsv"
             df.to_csv(full_df_file, sep='\t', index=False)
 
             # Calculate MRR for this file
@@ -93,7 +93,7 @@ def compute_mrr(output_dir, prompt_dir, correct_answer_file,
             mrr_scores.append(mrr)
             
             # Calculate top<n> of each rank
-            rank_df.loc[i,"lang"] = results_files[i][0:2]
+            rank_df.loc[i,"lang"] = results_files[i].split("/")[0]
             
             ppkts = df.groupby("label")[["rank","is_correct"]] 
             index_matches = df.index[df['is_correct']]
@@ -133,12 +133,12 @@ def compute_mrr(output_dir, prompt_dir, correct_answer_file,
 
     print("MRR scores are:\n")
     print(mrr_scores)
-    plot_data_file = plot_dir / "plotting_data.tsv"
+    mrr_file = plot_dir / "mrr_result.tsv"
 
     # write out results for plotting 
-    with plot_data_file.open('w', newline = '') as dat:
+    with mrr_file.open('w', newline = '') as dat:
         writer = csv.writer(dat, quoting = csv.QUOTE_NONNUMERIC, delimiter = '\t', lineterminator='\n')
         writer.writerow(results_files)
         writer.writerow(mrr_scores)
         
-    return plot_data_file, plot_dir, num_ppkt, topn_file
+    return mrr_file, plot_dir, num_ppkt, topn_file

--- a/src/malco/post_process/generate_plots.py
+++ b/src/malco/post_process/generate_plots.py
@@ -6,12 +6,11 @@ import csv
 
 # Make a nice plot, use it as function or as script
 
-def make_plots(plot_data_file, plot_dir, languages, num_ppkt, topn_file):
-    with plot_data_file.open('r', newline = '') as f:
+def make_plots(mrr_file, plot_dir, languages, num_ppkt, topn_file):
+    with mrr_file.open('r', newline = '') as f:
         lines = csv.reader(f, quoting = csv.QUOTE_NONNUMERIC, delimiter = '\t', lineterminator='\n')
         results_files = next(lines)
         mrr_scores = next(lines)
-        #lines = f.read().splitlines()
             
     print(results_files)
     print(mrr_scores)
@@ -23,6 +22,7 @@ def make_plots(plot_data_file, plot_dir, languages, num_ppkt, topn_file):
     plt.title("MRR of Correct Answers Across Different Results Files")
     plot_path = plot_dir /  (str(len(languages)) + "_langs_" + str(num_ppkt) + "ppkt.png")
     plt.savefig(plot_path)
+    plt.close()
 
     # Plotting bar-plots with top<n> ranks
     df = pd.read_csv(topn_file, delimiter='\t')
@@ -34,16 +34,16 @@ def make_plots(plot_data_file, plot_dir, languages, num_ppkt, topn_file):
     
     df_aggr = pd.DataFrame()
     df_aggr = pd.melt(df, id_vars="lang", value_vars=["top1", "top3", "top5", "top10", "not_found"], var_name="Rank_in", value_name="counts")
+    df_aggr["percentage"] = df_aggr["counts"]/num_ppkt
     bar_data_file = plot_dir / "topn_aggr.tsv"
     df_aggr.to_csv(bar_data_file, sep='\t', index=False)
 
-    sns.barplot(x="Rank_in", y="counts", data = df_aggr, hue = "lang")
+    sns.barplot(x="Rank_in", y="percentage", data = df_aggr, hue = "lang")
 
-    plt.xlabel("Number of Ranks")
-    plt.ylabel("Number of Correct Diagnoses")
-    plt.title("Rank Comparison for Different Languages")
+    plt.xlabel("Number of Ranks in")
+    plt.ylabel("Percentage of Cases")
+    plt.title("Rank Comparison for Differential Diagnosis")
     plot_path = plot_dir /  ("barplot_" + str(len(languages)) + "_langs_" + str(num_ppkt) + "ppkt.png")
     plt.savefig(plot_path)
-    plt.show()
-
+    plt.close()
     

--- a/src/malco/post_process/post_process.py
+++ b/src/malco/post_process/post_process.py
@@ -4,7 +4,7 @@ from malco.post_process.post_process_results_format import create_standardised_r
 import os
 
 
-def post_process(raw_results_dir: Path, output_dir: Path, langs: tuple) -> None:
+def post_process(raw_results_dir: Path, output_dir: Path, langs: tuple, models: tuple) -> None:
     """
     Post-process the raw results output to standardised PhEval TSV format.
 
@@ -14,10 +14,19 @@ def post_process(raw_results_dir: Path, output_dir: Path, langs: tuple) -> None:
     """
 
     for lang in langs:
-        raw_results_lang = raw_results_dir / lang
-        output_lang = output_dir / lang
-        raw_results_lang.mkdir(exist_ok=True)
-        output_lang.mkdir(exist_ok=True)
+        raw_results_lang = raw_results_dir / "multilingual" / lang
+        output_lang = output_dir / "multilingual" / lang
+        raw_results_lang.mkdir(exist_ok=True, parents=True)
+        output_lang.mkdir(exist_ok=True, parents=True)
 
         create_standardised_results(raw_results_dir=raw_results_lang,
                                     output_dir=output_lang, output_file_name="results.tsv")
+        
+    for model in models:
+        raw_results_model = raw_results_dir / "multimodel" / model
+        output_model = output_dir / "multimodel" / model
+        raw_results_model.mkdir(exist_ok=True, parents=True)
+        output_model.mkdir(exist_ok=True, parents=True)
+
+        create_standardised_results(raw_results_dir=raw_results_model,
+                                    output_dir=output_model, output_file_name="results.tsv")

--- a/src/malco/run/run.py
+++ b/src/malco/run/run.py
@@ -3,23 +3,34 @@ import multiprocessing
 import subprocess
 
 
-def call_ontogpt(lang, raw_results_dir, input_dir):
-    command = (
-        f"ontogpt -v run-multilingual-analysis "
-        f"--output={raw_results_dir}/{lang}/results.yaml "  # save raw OntoGPT output
-        f"{input_dir}/prompts/{lang}/ "
-        f"{raw_results_dir}/{lang}/differentials_by_file/"
-    )
+def call_ontogpt(lang, raw_results_dir, input_dir, model): 
+    if model=="gpt-4-turbo":
+        command = (
+            f"ontogpt -v run-multilingual-analysis "
+            f"--output={raw_results_dir}/{lang}/results.yaml "  # save raw OntoGPT output
+            f"{input_dir}/prompts/{lang}/ "
+            f"{raw_results_dir}/{lang}/differentials_by_file/ "
+            f"--model={model}"
+        )
+    else:
+        command = (
+            f"ontogpt -v run-multilingual-analysis "
+            f"--output={raw_results_dir}/{model}/results.yaml "  # save raw OntoGPT output
+            f"{input_dir}/prompts/{lang}/ "
+            f"{raw_results_dir}/{model}/differentials_by_file/ "
+            f"--model={model}"
+        )
     print(f"Running command: {command}")
     process = subprocess.Popen(command, shell=True)
     process.communicate()
-    print(f"Finished command for {lang}")
+    print(f"Finished command for language {lang} and model {model}") 
 
 
 def run(testdata_dir: Path,
         raw_results_dir: Path,
         input_dir: Path,
         langs: tuple,
+        models: tuple,
         max_workers: int = None) -> None:
     """
     Run the tool to obtain the raw results.
@@ -36,4 +47,12 @@ def run(testdata_dir: Path,
         max_workers = multiprocessing.cpu_count()
 
     with multiprocessing.Pool(processes=max_workers) as pool:
-        pool.starmap(call_ontogpt, [(lang, raw_results_dir, input_dir) for lang in langs])
+        pool.starmap(call_ontogpt, [(lang, raw_results_dir / "multilingual", input_dir, "gpt-4-turbo") for lang in langs])
+
+    # English only many models
+    #TODO
+    # 1323 of ontogpt/cli.py and
+    #   15 of ontogpt/utils/multilingual.py
+    # have to be edited (get rid of hardcoded model!)
+    with multiprocessing.Pool(processes=max_workers) as pool:
+        pool.starmap(call_ontogpt, [("en", raw_results_dir / "multimodel", input_dir, model) for model in models])


### PR DESCRIPTION
Several functions are called twice, output goes into multilingual dir and multimodel dir, present both within output and raw_results dirs. It is like a duplicated analysis, where multiple models are run for English only. This seems like a good first step.

Two hardcoded model name strings within ontogpt (its multilingual function) have to be edited in order for this to work. See

https://github.com/monarch-initiative/malco/blob/a805822ae49ab5a4bc6ed9a93f6bdc7b346b5a56/src/malco/run/run.py#L52-L56

Multiple models are added here: 
https://github.com/monarch-initiative/malco/blob/a805822ae49ab5a4bc6ed9a93f6bdc7b346b5a56/src/malco/runner.py#L22-L23